### PR TITLE
Update formula for bottom shear stress in ex2d_MMS.c

### DIFF
--- a/docs/sediment_equation.md
+++ b/docs/sediment_equation.md
@@ -180,7 +180,7 @@ E_i = M \left( \frac{\tau_b - \tau_{ce}}{\tau_{ce}} \right),
 D_i = w c_i \left[ 1 - \left( \frac{\tau_b}{\tau_{cd}} \right) \right],
 \end{equation}
 
-where, for each sediment class $i$, $M$ is the Krone-Partheniades erosion law constant [kg/m$^{2}$], or the erodibility coefficient, $w$ is the settling velocity for sediment class $i$ (m/s), $\tau_{ce}$ is critical shear stress for erosion (N/m$^2$), $\tau_{cd}$ is critical shear stress for deposition (N/m$^2$), $\tau_b = \rho C_D u\sqrt{u^2+v^2}$ is the bottom shear stress. 
+where, for each sediment class $i$, $M$ is the Krone-Partheniades erosion law constant [kg/m$^{2}$], or the erodibility coefficient, $w$ is the settling velocity for sediment class $i$ (m/s), $\tau_{ce}$ is critical shear stress for erosion (N/m$^2$), $\tau_{cd}$ is critical shear stress for deposition (N/m$^2$), $\tau_b = 0.5 \rho C_D (u^2+v^2)$ is the bottom shear stress. 
 
 Coupling sediment transport equation with Shallow Water Equations lead to:
 

--- a/sd/ex2d_MMS.c
+++ b/sd/ex2d_MMS.c
@@ -1324,8 +1324,7 @@ PetscErrorCode computeSEDbss(RDySed *sed, PetscInt icell, PetscReal Cd, PetscRea
   PetscFunctionBeginUser;
 
   PetscReal rhow     = 1000.0;  /// water density
-  PetscReal velocity = PetscSqrtReal(u * u + v * v);
-  sed->tau_b[icell]  = rhow * Cd * u * velocity;
+  sed->tau_b[icell]  = 0.5 * rhow * Cd * (u * u + v * v);
 
   PetscFunctionReturn(0);
 }
@@ -2716,7 +2715,7 @@ PetscErrorCode AddSourceTerm(RDyApp app, Vec F, PetscReal t) {
         tby_MMS = Cd_MMS * v_MMS * velocity_MMS;
 
         // MMS deposition and erosion
-        PetscReal tau_b_MMS = rhow * Cd_MMS * u_MMS * velocity_MMS;
+        PetscReal tau_b_MMS = 0.5 * rhow * Cd_MMS * (u_MMS * u_MMS + v_MMS * v_MMS);
         for (PetscInt j = 0; j < nsed; j++) {
           f_ptr[icell * ndof + 3 + j] -= sed->M[j] * (tau_b_MMS - sed->tau_ce[j]) / sed->tau_ce[j];  // Ei
           f_ptr[icell * ndof + 3 + j] += sed->vset[j] * C_MMS * (1 - tau_b_MMS / sed->tau_cd[j]);    // Di


### PR DESCRIPTION
Correct an error in the formula of bottom shear stress, which is now consistent to that in Tassi et al., (2023) (https://doi.org/10.1016/j.envsoft.2022.105544). The MMS test has been performed again to check convergency. The result is shown below. 
![norm_MMS_momentum_sed](https://github.com/user-attachments/assets/72416e1f-f0e5-413d-8129-642d46a54f5b)
